### PR TITLE
new feedstock at 4.0.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+aggregate_check: false
+
+channels:
+  - https://staging.continuum.io/prefect/fs/jupyter-server-mathjax-feedstock/pr2/52c49d1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_check: false
-
-channels:
-  - https://staging.continuum.io/prefect/fs/jupyter-server-mathjax-feedstock/pr2/52c49d1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true # [py<36 or s390x]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
@@ -32,9 +32,8 @@ requirements:
   host:
     - hatch-jupyter-builder >=0.5
     - hatchling >=1.5.0
-    - jupyterlab >=4.0.0,<5
     - pip
-    - python >=3.6
+    - python
   run:
     - colorama
     - gitpython !=2.1.4,!=2.1.5,!=2.1.6
@@ -43,7 +42,7 @@ requirements:
     - jupyter-server-mathjax >=0.2.2
     - nbformat
     - pygments
-    - python >=3.6
+    - python
     - requests
     - tornado
 


### PR DESCRIPTION
Changes:
- new feedstock at 4.0.1

jupyterlab not needed at build time because pypi package contains npm built resources.

https://github.com/jupyter/nbdime/tree/4.0.1